### PR TITLE
Fix definition of EVENTINJ in SVM.h

### DIFF
--- a/CommonTypes/SVM.h
+++ b/CommonTypes/SVM.h
@@ -418,7 +418,7 @@ namespace SVM
         unsigned long long Value;
         struct {
             unsigned long long Vector : 8; // IDT vector of the interrupt/exception (ignored if Type == 2)
-            unsigned long long Type : 2; // 0 = External/virtual interrupt (INTR), 2 = NMI, 3 = Exception (fault/trap), 4 = Software interrupt (INTn instruction)
+            unsigned long long Type : 3; // 0 = External/virtual interrupt (INTR), 2 = NMI, 3 = Exception (fault/trap), 4 = Software interrupt (INTn instruction)
             unsigned long long ErrorCodeValid : 1; // 1 - Exception should push an error code onto the stack
             unsigned long long Reserved : 19;
             unsigned long long Valid : 1; // 1 - Event is to be injected into the guest


### PR DESCRIPTION
The width of the bitmap fields don't add up to 32: `8 + 2 + 1 + 19 + 1 == 31`.

The correct width for `EVENTINJ.Type` is 3[^amdm] bits, not 2.

[^amdm]: [AMD64 Architecture Programmer's Manual Volume 2: System Programming](https://www.amd.com/system/files/TechDocs/24593.pdf), §15.20 "Event Injection"